### PR TITLE
fix typo

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -531,7 +531,7 @@ public class ApplicationConfiguration extends AsyncConfigurerSupport {
 
   @Override
   public Executor getAsyncExecutor() {
-    return new DelegatingSecurityContextExecutorService(Executors.new FixedThreadPool(5);
+    return new DelegatingSecurityContextExecutorService(Executors.newFixedThreadPool(5));
   }  
 
 }


### PR DESCRIPTION
probably  [Executors.newFixedThreadPool(5)](http://docs.oracle.com/javase/6/docs/api/java/util/concurrent/Executors.html#newFixedThreadPool(int)) was intended (without the space after new and with an additional closing bracket).